### PR TITLE
Changed vat_code to vat_number

### DIFF
--- a/RecurlySDK/REAddress.m
+++ b/RecurlySDK/REAddress.m
@@ -95,7 +95,7 @@ static NSDictionary *readAddress(ABRecordRef record)
     [dict setOptionalObject:_firstName forKey:@"first_name"];
     [dict setOptionalObject:_lastName forKey:@"last_name"];
     [dict setOptionalObject:_companyName forKey:@"company"];
-    [dict setOptionalObject:_vatCode forKey:@"vat_code"];
+    [dict setOptionalObject:_vatCode forKey:@"vat_number"];
     [dict setOptionalObject:_phone forKey:@"phone"];
 
     [dict setOptionalObject:_address1 forKey:@"address1"];


### PR DESCRIPTION
Noticed bug where vat_code was being sent instead of vat_number. This was preventing the vat number from being sent when creating card requests and updating billing address