### PR TITLE
workflow fix

### DIFF
--- a/.github/workflows/deploy_to_cocoapods.yaml
+++ b/.github/workflows/deploy_to_cocoapods.yaml
@@ -18,7 +18,8 @@ jobs:
     - name: Deploy to Cocoapods
       run: |
         set -eo pipefail
-        export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+        export VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+        export LIB_VERSION=${VERSION:1:6}
         pod lib lint --allow-warnings
         pod trunk push --allow-warnings
       env:

--- a/RecurlySDK.podspec
+++ b/RecurlySDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RecurlySDK"
-  s.version      = ENV['LIB_VERSION'] || "v2.0.0" 
+  s.version      = ENV['LIB_VERSION'] || "2.0.0" 
   s.summary      = "Integrate recurrent payments in your iOS app in a matter of minutes."
 
   s.homepage     = "https://dev.recurly.com/docs/client-libraries"
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
 
   s.platform     = :ios, '15.6'
-  s.source       = { :git => "https://github.com/recurly/recurly-client-ios.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/recurly/recurly-client-ios.git", :tag => "v#{s.version}" }
   s.source_files = 'RecurlySDK/*.{h,m}'
 
   s.frameworks   = 'UIKit', 'Foundation', 'Security', 'CoreGraphics', 'QuartzCore', 'PassKit', 'AddressBook', 'CoreTelephony'


### PR DESCRIPTION
cocoa registry expects version number with out the char v. Updated workflow to remove the v when it looks up the release version