### PR TITLE
Fix environment variable usage in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ struct ContainerApp: App {
 ```
 
 ### Unit Tests
-You can verify your API public key is working by running the tests in `RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift`. This file does not compile out of the box because it expects you to provide your `publicKey` in a separate file.
+`RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift` expects to receive environment variables (such as PUBLIC\_KEY) from the command line.
 
-In the `RecurlySDK-iOSTests` directory, create a `env.swift` file with the line `val publicKey = "<your public key>"` and run the tests in Xcode.
+If you'd like to run the tests in Xcode, be sure to set the `publicKey` variable directly in the test file with your own file. Tests won't pass without a valid public key that you provide.
 
 ## 4. Examples
 Once the SDK is imported and configured, we can start building stuff with it!

--- a/RecurlySDK-iOS.xcodeproj/project.pbxproj
+++ b/RecurlySDK-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		27F498F0275D146C009227F5 /* RETokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498EF275D146C009227F5 /* RETokenRequest.swift */; };
 		27F498F2275D1A78009227F5 /* RETokenizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498F1275D1A78009227F5 /* RETokenizationManager.swift */; };
 		27F548DE27724D4B001014C8 /* REApplePaymentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F548DD27724D4B001014C8 /* REApplePaymentHandler.swift */; };
+		5E07F71628CFAEA700F9E568 /* EnvHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E07F71528CFAEA700F9E568 /* EnvHelper.swift */; };
 		5E5C346E28B178BC000680CF /* RecurlySDK-iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5C346D28B178BC000680CF /* RecurlySDK-iOSTests.swift */; };
 		5E5C346F28B178BC000680CF /* RecurlySDK_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27DF9DAA274BC77D0093E7BA /* RecurlySDK_iOS.framework */; };
 		866B9B94278F4E6A009035C2 /* REApplePayInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866B9B93278F4E6A009035C2 /* REApplePayInfo.swift */; };
@@ -125,6 +126,7 @@
 		27F498EF275D146C009227F5 /* RETokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RETokenRequest.swift; sourceTree = "<group>"; };
 		27F498F1275D1A78009227F5 /* RETokenizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RETokenizationManager.swift; sourceTree = "<group>"; };
 		27F548DD27724D4B001014C8 /* REApplePaymentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = REApplePaymentHandler.swift; sourceTree = "<group>"; };
+		5E07F71528CFAEA700F9E568 /* EnvHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvHelper.swift; sourceTree = "<group>"; };
 		5E5C346B28B178BC000680CF /* RecurlySDK-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RecurlySDK-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E5C346D28B178BC000680CF /* RecurlySDK-iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecurlySDK-iOSTests.swift"; sourceTree = "<group>"; };
 		86450E1A2790BDF700DD5399 /* ContainerApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ContainerApp.entitlements; sourceTree = "<group>"; };
@@ -340,6 +342,7 @@
 			isa = PBXGroup;
 			children = (
 				5E5C346D28B178BC000680CF /* RecurlySDK-iOSTests.swift */,
+				5E07F71528CFAEA700F9E568 /* EnvHelper.swift */,
 			);
 			path = "RecurlySDK-iOSTests";
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E5C346E28B178BC000680CF /* RecurlySDK-iOSTests.swift in Sources */,
+				5E07F71628CFAEA700F9E568 /* EnvHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RecurlySDK-iOS.xcodeproj/xcshareddata/xcschemes/RecurlySDK-iOS.xcscheme
+++ b/RecurlySDK-iOS.xcodeproj/xcshareddata/xcschemes/RecurlySDK-iOS.xcscheme
@@ -26,7 +26,23 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E5C346A28B178BC000680CF"
+            BuildableName = "RecurlySDK-iOSTests.xctest"
+            BlueprintName = "RecurlySDK-iOSTests"
+            ReferencedContainer = "container:RecurlySDK-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PUBLIC_KEY"
+            value = "$(PUBLIC_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/RecurlySDK-iOSTests/EnvHelper.swift
+++ b/RecurlySDK-iOSTests/EnvHelper.swift
@@ -1,0 +1,12 @@
+//
+//  EnvHelper.swift
+//  RecurlySDK-iOSTests
+//
+//  Created by George Andrew Shoemaker on 9/12/22.
+//
+
+import Foundation
+
+func getEnviornmentVar(_ name: String) -> String?{
+    return ProcessInfo.processInfo.environment["PUBLIC_KEY"]
+}

--- a/RecurlySDK-iOSTests/env.swift
+++ b/RecurlySDK-iOSTests/env.swift
@@ -1,1 +1,0 @@
-let publicKey = ProcessInfo.processInfo.environment["API_TOKEN"]


### PR DESCRIPTION
@ Mark R

The test file is now setup to receive a PUBLIC_KEY argument from the command line.

Here's an example test command I've been using:
```
xcodebuild \
-project RecurlySDK-iOS.xcodeproj \
-scheme RecurlySDK-iOS \
-destination 'platform=iOS Simulator,name=iPhone 13' \
PUBLIC_KEY=value \
test \
```

I also updated the README.md with hints about running the test from Xcode