### PR TITLE
Specify deployment target for SPM package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "recurly-client-ios",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "recurly-client-ios",
+    platforms: [
+        .iOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/RecurlySDK-iOS/Models/RECardData.swift
+++ b/RecurlySDK-iOS/Models/RECardData.swift
@@ -10,11 +10,29 @@ import Foundation
 /// Recurly Card Data Model
 public struct RECardData: Codable {
     /// Credit Card number
-    var number: String = ""
+    var number: String
     /// Expiration Month
-    var month: String = ""
+    var month: String
     /// Expiration Year
-    var year: String = ""
+    var year: String
     /// Security Code
-    var cvv: String = ""
+    var cvv: String
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case month
+        case year
+        case cvv
+    }
+    
+    public init(number: String = "",
+                month: String = "",
+                year: String = "",
+                cvv: String = "") {
+        
+        self.number = number
+        self.month = month
+        self.year = year
+        self.cvv = cvv
+    }
 }

--- a/RecurlySDK-iOS/Networking/RETokenizationManager.swift
+++ b/RecurlySDK-iOS/Networking/RETokenizationManager.swift
@@ -39,6 +39,12 @@ public struct RETokenizationManager {
     public mutating func setApplePaymentMethod(applePaymentMethod: REApplePaymentMethod) {
         self.applePaymentMethod = applePaymentMethod
     }
+
+    /// Set the Card Data that its going to be send for tokenization
+    /// - Parameter cardData: The CardData received from the User
+    public mutating func setCardData(cardData: RECardData) {
+        self.cardData = cardData
+    }
     
     /// Returns the tokenId as String from a BillingInfo or/with CardData tokenization request.
     ///

--- a/RecurlySDK-iOS/Networking/TokenizationAPI.swift
+++ b/RecurlySDK-iOS/Networking/TokenizationAPI.swift
@@ -23,9 +23,15 @@ extension TokenizationAPI: BaseRequest {
     }
     
     var baseURL: String {
+        let defaultURL = "api.recurly.com/js/v1"
+        let defaultURLEU = "api.eu.recurly.com/js/v1"
+        
         switch self {
         default:
-            return "api.recurly.com/js/v1"
+            if REConfiguration.shared.apiPublicKey.starts(with: "fra-") {
+                return defaultURLEU
+            }
+            return defaultURL
         }
     }
     


### PR DESCRIPTION
Omitting the deployment target and iOS 14 as minimal deployment version will lead to multiple build errors like **"... is only available on iOS 13/14 or newer"** when SDK is imported with Swift Package Manager.
![build-errors](https://github.com/recurly/recurly-client-ios/assets/2015453/35391665-4e02-420c-ae1c-22a7108ed5fc)
