### PR TITLE
Clean up Package.swift definition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "Recurly",
-            targets: ["RecurlySDK-iOS"]
+            targets: ["Recurly"]
         )
     ],
     dependencies: [
@@ -22,12 +22,12 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "RecurlySDK-iOS",
+            name: "Recurly",
             dependencies: [],
             path: "RecurlySDK-iOS"),
         .testTarget(
-            name: "RecurlySDK-iOSTests",
-            dependencies: ["RecurlySDK-iOS"],
+            name: "RecurlyTests",
+            dependencies: ["Recurly"],
             path: "RecurlySDK-iOSTests")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,18 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "recurly-client-ios",
+    platforms: [
+        .iOS(.v14) // Adjust if you need to support an earlier version
+    ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "RecurlySDK-iOS",
-            targets: ["RecurlySDK-iOS"]),
+            name: "RecurlySDK",
+            targets: ["RecurlySDK-iOS"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.

--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,13 @@
 import PackageDescription
 
 let package = Package(
-    name: "recurly-client-ios",
+    name: "Recurly",
     platforms: [
         .iOS(.v14) // Adjust if you need to support an earlier version
     ],
     products: [
         .library(
-            name: "RecurlySDK",
+            name: "Recurly",
             targets: ["RecurlySDK-iOS"]
         )
     ],
@@ -28,6 +28,6 @@ let package = Package(
         .testTarget(
             name: "RecurlySDK-iOSTests",
             dependencies: ["RecurlySDK-iOS"],
-            path: "RecurlySDK-iOSTests"),
+            path: "RecurlySDK-iOSTests")
     ]
 )


### PR DESCRIPTION
As mentioned in #42 , the existing `Package.swift` is incomplete and does not specify a minimum iOS deployment version. When imported as a Swift Package, this omission results in over 100 compiler errors.

This PR:
- Adds a minimum iOS deployment version of iOS 14 and newer (necessary to support all currently-used API's)
- Updates the Swift Package Product & Target names to be more "Swift-y"
  - Instead of needing to use `import RecurlySDK_iOS`, we now just need `import Recurly`. 
    - The "SDK_iOS" suffix is unnecessary since this library is only ever consumed by iOS clients intending on using the SDK.


![CleanShot 2025-03-26 at 12 31 51@2x](https://github.com/user-attachments/assets/8ecbbad0-c14f-450d-9736-869b8257fbef)

