### PR TITLE
ci: Remediate Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -12,7 +12,6 @@ on:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Run_Tests:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -12,12 +12,13 @@ on:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Run_Tests:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Select Xcode
       run: sudo xcode-select -switch /Applications/Xcode_16.2.app && /usr/bin/xcodebuild -version
 

--- a/.github/workflows/deploy_to_cocoapods.yaml
+++ b/.github/workflows/deploy_to_cocoapods.yaml
@@ -2,7 +2,6 @@ name: deploy_to_cocoapods
 on:
   release:
     types: [released]
-
 jobs:
   build:
     runs-on: macos-14

--- a/.github/workflows/deploy_to_cocoapods.yaml
+++ b/.github/workflows/deploy_to_cocoapods.yaml
@@ -3,9 +3,6 @@ on:
   release:
     types: [released]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: macos-14

--- a/.github/workflows/deploy_to_cocoapods.yaml
+++ b/.github/workflows/deploy_to_cocoapods.yaml
@@ -2,11 +2,15 @@ name: deploy_to_cocoapods
 on:
   release:
     types: [released]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6.0.2
     - name: Select Xcode
       run: sudo xcode-select -switch /Applications/Xcode_16.2.app && /usr/bin/xcodebuild -version
     - name: List Simulators


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions on node20 or earlier will be forced to run with Node.js 24 starting June 2, 2026, and node20 will be removed from runners on September 16, 2026.

### Fix
Updated the following actions to Node.js 24-compatible versions:
- `actions/checkout`: v3 → v6.0.2 (node16 → node24) in `deploy_to_cocoapods.yaml`
- `actions/checkout`: v4 → v6.0.2 (node20 → node24) in `ci-test.yaml`

### Files Changed
- `.github/workflows/ci-test.yaml` — updated `actions/checkout` from v4 to v6.0.2; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` validation flag
- `.github/workflows/deploy_to_cocoapods.yaml` — updated `actions/checkout` from v3 to v6.0.2; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` validation flag

## Testing
Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` flag to validate that all JavaScript actions run successfully under Node.js 24. CI results: pending