### PR TITLE
Route tokenization requests to EU data center for fra- public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ struct ContainerApp: App {
 }
 ```
 
+#### EU Data Residency
+If your Recurly site is hosted in Recurly's EU data center, your public key is prefixed with `fra-`. The SDK automatically detects this prefix and routes tokenization requests to the EU endpoint (`api.eu.recurly.com`) instead of the default US endpoint (`api.recurly.com`) — no additional configuration is required. Make sure `REConfiguration.shared.initialize(publicKey:)` is called before performing any tokenization so the correct endpoint is used.
+
 ### Unit Tests
 `RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift` expects to receive environment variables (such as PUBLIC\_KEY) from the command line.
 

--- a/RecurlySDK-iOS/Networking/TokenizationAPI.swift
+++ b/RecurlySDK-iOS/Networking/TokenizationAPI.swift
@@ -25,7 +25,9 @@ extension TokenizationAPI: BaseRequest {
     var baseURL: String {
         switch self {
         default:
-            return "api.recurly.com/js/v1"
+            return REConfiguration.shared.apiPublicKey.hasPrefix("fra-")
+                ? "api.eu.recurly.com/js/v1"
+                : "api.recurly.com/js/v1"
         }
     }
     

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -22,6 +22,10 @@ class RecurlySDK_iOSTests: XCTestCase {
         // Prevent state from a stubbed MockURLProtocol.requestHandler leaking into
         // the next test (XCTest execution order is not guaranteed).
         MockURLProtocol.requestHandler = nil
+        // Prevent REConfiguration.shared.apiPublicKey (global static) from leaking
+        // between tests — e.g. EU-routing tests set a "fra-" key that must not
+        // bleed into other TokenizationAPI assertions (XCTest order is not guaranteed).
+        REConfiguration.shared.apiPublicKey = ""
         super.tearDown()
     }
     
@@ -564,6 +568,28 @@ class RecurlySDK_iOSTests: XCTestCase {
     func testTokenizationAPI_getApplePayTokenID_path() {
         XCTAssertEqual(TokenizationAPI.getApplePayTokenID.path, "/apple_pay/token")
         XCTAssertEqual(TokenizationAPI.getApplePayTokenID.absoluteString, "https://api.recurly.com/js/v1/apple_pay/token")
+    }
+
+    func testTokenizationAPI_euKeyPrefix_routesToEUHost() {
+        REConfiguration.shared.apiPublicKey = "fra-test123"
+        XCTAssertEqual(TokenizationAPI.getTokenID.baseURL, "api.eu.recurly.com/js/v1")
+        XCTAssertEqual(TokenizationAPI.getTokenID.absoluteString, "https://api.eu.recurly.com/js/v1/tokens")
+    }
+
+    func testTokenizationAPI_euKeyPrefix_routesApplePayToEUHost() {
+        REConfiguration.shared.apiPublicKey = "fra-test123"
+        XCTAssertEqual(TokenizationAPI.getApplePayTokenID.absoluteString, "https://api.eu.recurly.com/js/v1/apple_pay/token")
+    }
+
+    func testTokenizationAPI_usKey_routesToUSHost() {
+        REConfiguration.shared.apiPublicKey = "pub-test123"
+        XCTAssertEqual(TokenizationAPI.getTokenID.baseURL, "api.recurly.com/js/v1")
+        XCTAssertEqual(TokenizationAPI.getTokenID.absoluteString, "https://api.recurly.com/js/v1/tokens")
+    }
+
+    func testTokenizationAPI_emptyKey_defaultsToUSHost() {
+        REConfiguration.shared.apiPublicKey = ""
+        XCTAssertEqual(TokenizationAPI.getTokenID.baseURL, "api.recurly.com/js/v1")
     }
 
     // MARK: Extensions


### PR DESCRIPTION
## Summary
Public keys prefixed with `fra-` now route tokenization and Apple Pay tokenization requests to Recurly's EU data center (`api.eu.recurly.com`) instead of the default US endpoint (`api.recurly.com`). This matches the detection behavior already used in recurly-js. No integrator configuration change is required — the SDK detects the key prefix automatically.

## Changes
- `TokenizationAPI.baseURL` checks `REConfiguration.shared.apiPublicKey` for the `fra-` prefix and routes accordingly (covers both `/tokens` and `/apple_pay/token`)
- Added offline unit tests covering: EU key routing, US key routing, empty key default, and Apple Pay EU routing
- Documented EU data residency behavior in README, including that `initialize(publicKey:)` must be called before tokenization for routing to apply
