### PR TITLE
fix: remove URLSession flake from NetworkEngine unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,21 @@ After reviewing our SDK via GitHub, use one of these two options to begin using 
 	```
 3. Select the version rule you want (e.g. "Up to Next Major") and add the package to your app target.
 
-Alternatively, add it directly to your `Package.swift`:
+Alternatively, add it directly to your `Package.swift` — declare the package
+dependency and add the `RecurlySDK` product to your target:
 
 	```swift
-	.package(url: "https://github.com/recurly/recurly-client-ios.git", from: "3.0.0")
+	dependencies: [
+	    .package(url: "https://github.com/recurly/recurly-client-ios.git", from: "3.0.0")
+	],
+	targets: [
+	    .target(
+	        name: "YourApp",
+	        dependencies: [
+	            .product(name: "RecurlySDK", package: "recurly-client-ios")
+	        ]
+	    )
+	]
 	```
 
 ### 1.2 Using CocoaPods

--- a/RecurlySDK-iOS/Networking/NetworkEngine.swift
+++ b/RecurlySDK-iOS/Networking/NetworkEngine.swift
@@ -55,41 +55,44 @@ class NetworkEngine {
     func sendRequest<T:Codable>(responseModel: T.Type, request: URLRequest, completionHandler: @escaping (Result<T, RecurlyBaseErrorResponse>) -> ()) {
         
         session.dataTask(with: request as URLRequest, completionHandler: { data, response, error in
-            if let error = error {
-                completionHandler(.failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "network-error",
-                                                                                    message: error.localizedDescription,
-                                                                                    details: []))))
-                return
-            }
-            
-            guard let data = data else {
-                completionHandler(.failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "network-error",
-                                                                                    message: "No data received",
-                                                                                    details: []))))
-                return
-            }
-            
-            let decoder = JSONDecoder()
-            if let errorResponse = try? decoder.decode(RecurlyBaseErrorResponse.self, from: data) {
-                completionHandler(.failure(errorResponse))
-                return
-            }
-            
-            if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
-                completionHandler(.failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "http-\(httpResponse.statusCode)",
-                                                                                    message: "Unexpected HTTP status code \(httpResponse.statusCode)",
-                                                                                    details: []))))
-                return
-            }
-                
-            do {
-                let response = try decoder.decode(responseModel.self, from: data)
-                completionHandler(.success(response))
-            } catch {
-                completionHandler(.failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
-                                                                                   message: "Internal Mapping Error",
-                                                                                   details: []))))
-            }
+            completionHandler(self.mapResponse(data, response, error, responseModel: responseModel))
         }).resume()
+    }
+    
+    func mapResponse<T: Codable>(_ data: Data?,
+                                  _ response: URLResponse?,
+                                  _ error: Error?,
+                                  responseModel: T.Type) -> Result<T, RecurlyBaseErrorResponse> {
+        if let error = error {
+            return .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "network-error",
+                                                                                message: error.localizedDescription,
+                                                                                details: [])))
+        }
+        
+        guard let data = data else {
+            return .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "network-error",
+                                                                                message: "No data received",
+                                                                                details: [])))
+        }
+        
+        let decoder = JSONDecoder()
+        if let errorResponse = try? decoder.decode(RecurlyBaseErrorResponse.self, from: data) {
+            return .failure(errorResponse)
+        }
+        
+        if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+            return .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "http-\(httpResponse.statusCode)",
+                                                                                message: "Unexpected HTTP status code \(httpResponse.statusCode)",
+                                                                                details: [])))
+        }
+        
+        do {
+            let response = try decoder.decode(responseModel.self, from: data)
+            return .success(response)
+        } catch {
+            return .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
+                                                                               message: "Internal Mapping Error",
+                                                                               details: [])))
+        }
     }
 }

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -193,12 +193,99 @@ class RecurlySDK_iOSTests: XCTestCase {
     func testNetworkEngine_sendRequest_success() {
         let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
         let responseJSON = "{\"id\":\"tok-123\",\"type\":\"credit_card\"}".data(using: .utf8)!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(responseJSON, response, nil, responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success(let response):
+            XCTAssertEqual(response.id, "tok-123")
+        case .failure(let error):
+            XCTFail("unexpected failure: \(String(describing: error.error.message))")
+        }
+    }
+
+    func testNetworkEngine_sendRequest_recurlyErrorBody() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let errorJSON = "{\"error\":{\"code\":\"invalid-parameter\",\"message\":\"boom\",\"details\":[]}}".data(using: .utf8)!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(errorJSON, response, nil, responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success:
+            XCTFail("expected failure")
+        case .failure(let error):
+            XCTAssertEqual(error.error.code, "invalid-parameter")
+        }
+    }
+
+    func testNetworkEngine_sendRequest_transportError() {
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(nil, nil, URLError(.notConnectedToInternet), responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success:
+            XCTFail("expected failure")
+        case .failure(let error):
+            XCTAssertEqual(error.error.code, "network-error")
+        }
+    }
+
+    func testNetworkEngine_sendRequest_nonSuccessStatusCode() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let body = "{}".data(using: .utf8)!
+        let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)
+
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(body, response, nil, responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success:
+            XCTFail("expected failure")
+        case .failure(let error):
+            XCTAssertEqual(error.error.code, "http-500")
+        }
+    }
+
+    func testNetworkEngine_sendRequest_undecodableSuccessBody_returnsSdkInternal() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let garbage = "not json".data(using: .utf8)!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(garbage, response, nil, responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success:
+            XCTFail("expected failure")
+        case .failure(let error):
+            XCTAssertEqual(error.error.code, "sdk-internal")
+        }
+    }
+
+
+    func testNetworkEngine_mapResponse_noData_returnsNetworkError() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        let engine = NetworkEngine()
+        let result = engine.mapResponse(nil, response, nil, responseModel: RecurlyTokenResponse.self)
+        switch result {
+        case .success:
+            XCTFail("expected failure")
+        case .failure(let error):
+            XCTAssertEqual(error.error.code, "network-error")
+        }
+    }
+
+
+    func testNetworkEngine_sendRequest_wiredThroughURLSession_success() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let responseJSON = "{\"id\":\"tok-123\",\"type\":\"credit_card\"}".data(using: .utf8)!
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
         }
 
         let engine = NetworkEngine(session: MockURLProtocol.makeSession())
-        let expectation = expectation(description: "success")
+        let expectation = expectation(description: "wiredThroughURLSession_success")
         engine.sendRequest(responseModel: RecurlyTokenResponse.self, request: URLRequest(url: url)) { result in
             switch result {
             case .success(let response):
@@ -208,52 +295,12 @@ class RecurlySDK_iOSTests: XCTestCase {
                 XCTFail("unexpected failure: \(String(describing: error.error.message))")
             }
         }
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testNetworkEngine_sendRequest_recurlyErrorBody() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let errorJSON = "{\"error\":{\"code\":\"invalid-parameter\",\"message\":\"boom\",\"details\":[]}}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), errorJSON, nil)
-        }
-
-        let engine = NetworkEngine(session: MockURLProtocol.makeSession())
-        let expectation = expectation(description: "recurlyErrorBody")
-        engine.sendRequest(responseModel: RecurlyTokenResponse.self, request: URLRequest(url: url)) { result in
-            switch result {
-            case .success:
-                XCTFail("expected failure")
-            case .failure(let error):
-                XCTAssertEqual(error.error.code, "invalid-parameter")
-                expectation.fulfill()
-            }
-        }
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testNetworkEngine_sendRequest_transportError() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        MockURLProtocol.requestHandler = { _ in
-            (nil, nil, URLError(.notConnectedToInternet))
-        }
-
-        let engine = NetworkEngine(session: MockURLProtocol.makeSession())
-        let expectation = expectation(description: "transportError")
-        engine.sendRequest(responseModel: RecurlyTokenResponse.self, request: URLRequest(url: url)) { result in
-            switch result {
-            case .success:
-                XCTFail("expected failure")
-            case .failure(let error):
-                XCTAssertEqual(error.error.code, "network-error")
-                expectation.fulfill()
-            }
-        }
-        // Longer timeout: URLProtocol error delivery can be slow in CI.
+        // Generous timeout: exercises the real dataTask(...).resume() wiring end-to-end.
         wait(for: [expectation], timeout: 10.0)
     }
 
-    func testNetworkEngine_sendRequest_nonSuccessStatusCode() {
+
+    func testNetworkEngine_sendRequest_wiredThroughURLSession_httpErrorStatus() {
         let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
         let body = "{}".data(using: .utf8)!
         MockURLProtocol.requestHandler = { request in
@@ -261,7 +308,7 @@ class RecurlySDK_iOSTests: XCTestCase {
         }
 
         let engine = NetworkEngine(session: MockURLProtocol.makeSession())
-        let expectation = expectation(description: "nonSuccessStatusCode")
+        let expectation = expectation(description: "wiredThroughURLSession_httpErrorStatus")
         engine.sendRequest(responseModel: RecurlyTokenResponse.self, request: URLRequest(url: url)) { result in
             switch result {
             case .success:
@@ -271,28 +318,8 @@ class RecurlySDK_iOSTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testNetworkEngine_sendRequest_undecodableSuccessBody_returnsSdkInternal() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let garbage = "not json".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), garbage, nil)
-        }
-
-        let engine = NetworkEngine(session: MockURLProtocol.makeSession())
-        let expectation = expectation(description: "undecodableSuccessBody")
-        engine.sendRequest(responseModel: RecurlyTokenResponse.self, request: URLRequest(url: url)) { result in
-            switch result {
-            case .success:
-                XCTFail("expected failure")
-            case .failure(let error):
-                XCTAssertEqual(error.error.code, "sdk-internal")
-                expectation.fulfill()
-            }
-        }
-        wait(for: [expectation], timeout: 1.0)
+        // Generous timeout: exercises real dataTask(...).resume() failure delivery.
+        wait(for: [expectation], timeout: 10.0)
     }
 
     func testNetworkEngine_createPOSTRequest_setsTimeoutIntervalTo30() {


### PR DESCRIPTION
## Summary
Removes the real URLSession from the NetworkEngine unit tests to fix the intermittent CI timeout on the transport-error test, by extracting the response-mapping logic into a synchronous seam.

## Changes
- Extract NetworkEngine's response mapping into a synchronous `mapResponse(_:_:_:responseModel:)`; `sendRequest` is now a thin wrapper, behavior unchanged.
- Convert the NetworkEngine response tests to synchronous `mapResponse` calls; add coverage for the nil-data branch.
- Add two integration tests through `URLSession` + `MockURLProtocol` (success and http-500) for `dataTask` wiring.
- Complete the README Swift Package Manager example with the target `.product(...)` entry.