### PR TITLE
feat: add richer token response with card metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,41 @@ RecurlyTokenizationManager.shared.getTokenId { tokenId, error in
         }
 ```
 
+### Get a token with card metadata
+
+If you need the card details associated with the token (for example, to display a
+saved-card summary), use `getToken` instead of `getTokenId`. It returns a
+`RecurlyToken` containing the token `id`, the `type`, and a `card` with the
+brand, first six / last four digits, expiration, issuing country, and funding
+source when Recurly returns them.
+
+```Swift
+RecurlyTokenizationManager.shared.getToken { token, error in
+        if let errorResponse = error {
+            print(errorResponse.error.message ?? "")
+            return
+        }
+        guard let token = token else { return }
+        // Send token.id to your server to create the subscription / purchase.
+        // Use the card metadata to render a saved-card summary in your UI, e.g.:
+        //   "\(card.brand ?? "") •••• \(card.lastFour ?? "")"
+        if let card = token.card {
+            self.updateSavedCardLabel(brand: card.brand,
+                                      lastFour: card.lastFour,
+                                      expMonth: card.expMonth,
+                                      expYear: card.expYear)
+        }
+    }
+```
+
+> Card metadata (`brand`, `lastFour`, `expMonth`/`expYear`, etc.) is cardholder
+> data. It is safe to display for a card-on-file UI, but avoid writing it to logs
+> or third-party analytics/crash reporters in production.
+
+The same is available for Apple Pay via `getApplePayToken`. The existing
+`getTokenId` / `getApplePayTokenId` methods are unchanged and still return just
+the token id.
+
 ## 5. Apple Pay support
 
 The following assumes your company is setup as an Apple Pay merchant. For more info on configuration and setup, look at the `README-APPLE-PAY-CONFIG.md` documentation in the repo.

--- a/RecurlySDK-iOS.xcodeproj/project.pbxproj
+++ b/RecurlySDK-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		27F498E2275984CC009227F5 /* RecurlyBillingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498E1275984CC009227F5 /* RecurlyBillingInfo.swift */; };
 		27F498E42759974F009227F5 /* TokenizationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498E32759974F009227F5 /* TokenizationAPI.swift */; };
 		27F498E62759B99F009227F5 /* RecurlyTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498E52759B99F009227F5 /* RecurlyTokenResponse.swift */; };
+		1ACEE40D00000000000000B2 /* RecurlyToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACEE40D00000000000000A1 /* RecurlyToken.swift */; };
 		27F498E82759BBA1009227F5 /* RecurlyBaseErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498E72759BBA1009227F5 /* RecurlyBaseErrorResponse.swift */; };
 		27F498EC275A504B009227F5 /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498EB275A504B009227F5 /* UIDevice+Extension.swift */; };
 		27F498EE275D118F009227F5 /* RecurlyCardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F498ED275D118F009227F5 /* RecurlyCardData.swift */; };
@@ -125,6 +126,7 @@
 		27F498E1275984CC009227F5 /* RecurlyBillingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurlyBillingInfo.swift; sourceTree = "<group>"; };
 		27F498E32759974F009227F5 /* TokenizationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizationAPI.swift; sourceTree = "<group>"; };
 		27F498E52759B99F009227F5 /* RecurlyTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurlyTokenResponse.swift; sourceTree = "<group>"; };
+		1ACEE40D00000000000000A1 /* RecurlyToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurlyToken.swift; sourceTree = "<group>"; };
 		27F498E72759BBA1009227F5 /* RecurlyBaseErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurlyBaseErrorResponse.swift; sourceTree = "<group>"; };
 		27F498EB275A504B009227F5 /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
 		27F498ED275D118F009227F5 /* RecurlyCardData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurlyCardData.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				27F498ED275D118F009227F5 /* RecurlyCardData.swift */,
 				27F498E1275984CC009227F5 /* RecurlyBillingInfo.swift */,
 				27F498E52759B99F009227F5 /* RecurlyTokenResponse.swift */,
+				1ACEE40D00000000000000A1 /* RecurlyToken.swift */,
 				27F498E72759BBA1009227F5 /* RecurlyBaseErrorResponse.swift */,
 				866B9B93278F4E6A009035C2 /* RecurlyApplePayInfo.swift */,
 				868986882791EC8E00485118 /* RecurlyApplePayItem.swift */,
@@ -535,6 +538,7 @@
 				E925776C2AB4F32200820B2C /* Resource.swift in Sources */,
 				27830A4527553F5F00B2620C /* RecurlyCardNumberTextField.swift in Sources */,
 				27F498E62759B99F009227F5 /* RecurlyTokenResponse.swift in Sources */,
+				1ACEE40D00000000000000B2 /* RecurlyToken.swift in Sources */,
 				27830A4F27554FDC00B2620C /* UnifiedViewModel.swift in Sources */,
 				277F56B0274E7ECE0067E4E1 /* FontLoader.swift in Sources */,
 				277F56B3274E85FC0067E4E1 /* View+Extension.swift in Sources */,

--- a/RecurlySDK-iOS/Models/RecurlyToken.swift
+++ b/RecurlySDK-iOS/Models/RecurlyToken.swift
@@ -1,0 +1,44 @@
+//
+//  RecurlyToken.swift
+//  RecurlySDK-iOS
+//
+
+import Foundation
+
+/// The token returned by a successful tokenization request.
+public struct RecurlyToken: Sendable {
+    /// The token id to be used for creating a subscription, purchase, or account.
+    public var id: String
+    /// The token type (e.g. "credit_card" or "apple_pay").
+    public var type: String?
+    /// Card metadata associated with the token, when available.
+    public var card: RecurlyTokenCard?
+}
+
+/// Card metadata returned alongside a token.
+public struct RecurlyTokenCard: Codable, Sendable {
+    /// The card brand (e.g. "visa", "master", "american_express").
+    public var brand: String?
+    /// The first six digits of the card number (BIN).
+    public var firstSix: String?
+    /// The last four digits of the card number.
+    public var lastFour: String?
+    /// The card's expiration month.
+    public var expMonth: Int?
+    /// The card's expiration year.
+    public var expYear: Int?
+    /// ISO 3166-1 alpha-2 issuing country code. "ZZ" if unknown.
+    public var issuingCountry: String?
+    /// The card's funding source (e.g. "credit", "debit", "prepaid").
+    public var fundingSource: String?
+
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case firstSix = "first_six"
+        case lastFour = "last_four"
+        case expMonth = "exp_month"
+        case expYear = "exp_year"
+        case issuingCountry = "issuing_country"
+        case fundingSource = "funding_source"
+    }
+}

--- a/RecurlySDK-iOS/Models/RecurlyTokenResponse.swift
+++ b/RecurlySDK-iOS/Models/RecurlyTokenResponse.swift
@@ -8,4 +8,5 @@ import Foundation
 struct RecurlyTokenResponse: Codable, Sendable {
     var type: String?
     var id: String?
+    var card: RecurlyTokenCard?
 }

--- a/RecurlySDK-iOS/Networking/RecurlyAPIClient.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyAPIClient.swift
@@ -6,12 +6,36 @@
 import Foundation
 import Combine
 
-struct RecurlyAPIClient {
+/// Seam allowing `RecurlyTokenizationManager` to be tested with an injected fake, without
+/// driving a real `URLSession` round-trip through `NetworkEngine`.
+protocol TokenAPIClient {
+    func getToken<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<RecurlyToken, Error>
+    func getTokenID<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<String, Error>
+}
+
+struct RecurlyAPIClient: TokenAPIClient {
     
     private let networkEngine: NetworkEngine
     
     init(networkEngine: NetworkEngine = NetworkEngine()) {
         self.networkEngine = networkEngine
+    }
+    
+    /// Maps a decoded tokenization response into the public `RecurlyToken`, or a "missing id"
+    /// SDK-internal error when the response lacks one. Pure and side-effect free — this is the
+    /// seam used to unit test the success/failure mapping without a network round-trip.
+    static func makeToken(from result: Result<RecurlyTokenResponse, RecurlyBaseErrorResponse>) -> Result<RecurlyToken, Error> {
+        switch result {
+        case .success(let response):
+            guard let id = response.id, !id.isEmpty else {
+                return .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
+                                                                         message: "Token response missing id",
+                                                                         details: [])))
+            }
+            return .success(RecurlyToken(id: id, type: response.type, card: response.card))
+        case .failure(let errorResponse):
+            return .failure(errorResponse)
+        }
     }
     
     /// Sends a tokenization request and emits the full `RecurlyToken` (id, type, and card metadata when present).
@@ -26,18 +50,12 @@ struct RecurlyAPIClient {
         
         let subject = PassthroughSubject<RecurlyToken, Error>()
         networkEngine.sendRequest(responseModel: RecurlyTokenResponse.self, request: request) { result in
-            switch result {
-            case .success(let response):
-                guard let id = response.id, !id.isEmpty else {
-                    subject.send(completion: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
-                                                                                               message: "Token response missing id",
-                                                                                               details: []))))
-                    return
-                }
-                subject.send(RecurlyToken(id: id, type: response.type, card: response.card))
+            switch Self.makeToken(from: result) {
+            case .success(let token):
+                subject.send(token)
                 subject.send(completion: .finished)
-            case .failure(let errorResponse):
-                subject.send(completion: .failure(errorResponse))
+            case .failure(let error):
+                subject.send(completion: .failure(error))
             }
         }
         

--- a/RecurlySDK-iOS/Networking/RecurlyAPIClient.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyAPIClient.swift
@@ -14,7 +14,8 @@ struct RecurlyAPIClient {
         self.networkEngine = networkEngine
     }
     
-    func getTokenID<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<String, Error> {
+    /// Sends a tokenization request and emits the full `RecurlyToken` (id, type, and card metadata when present).
+    func getToken<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<RecurlyToken, Error> {
         guard let request = networkEngine.createPOSTRequest(requestType: requestType,
                                                             requestBody: dataRequest) else {
             let error = RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
@@ -23,7 +24,7 @@ struct RecurlyAPIClient {
             return Fail(error: error).eraseToAnyPublisher()
         }
         
-        let subject = PassthroughSubject<String, Error>()
+        let subject = PassthroughSubject<RecurlyToken, Error>()
         networkEngine.sendRequest(responseModel: RecurlyTokenResponse.self, request: request) { result in
             switch result {
             case .success(let response):
@@ -33,7 +34,7 @@ struct RecurlyAPIClient {
                                                                                                details: []))))
                     return
                 }
-                subject.send(id)
+                subject.send(RecurlyToken(id: id, type: response.type, card: response.card))
                 subject.send(completion: .finished)
             case .failure(let errorResponse):
                 subject.send(completion: .failure(errorResponse))
@@ -41,6 +42,13 @@ struct RecurlyAPIClient {
         }
         
         return subject.eraseToAnyPublisher()
+    }
+    
+    /// Sends a tokenization request and emits the token id only.
+    func getTokenID<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<String, Error> {
+        getToken(with: dataRequest, requestType: requestType)
+            .map(\.id)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
@@ -69,9 +69,9 @@ public final class RecurlyTokenizationManager {
         }
     }
 
-    private let apiClient: RecurlyAPIClient
+    private let apiClient: TokenAPIClient
 
-    internal init(apiClient: RecurlyAPIClient = RecurlyAPIClient()) {
+    internal init(apiClient: TokenAPIClient = RecurlyAPIClient()) {
         self.apiClient = apiClient
     }
 

--- a/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
@@ -99,6 +99,17 @@ public final class RecurlyTokenizationManager {
     ///
     /// - Parameter completion: (TokenId, Error)
     public func getTokenId(completion: @escaping (String?, RecurlyBaseErrorResponse?) -> ()) {
+        getToken { token, error in
+            completion(token?.id, error)
+        }
+    }
+    
+    /// Returns the tokenized `RecurlyToken` (id, type, and card metadata when present) from a BillingInfo or/with CardData tokenization request.
+    ///
+    /// Sends the CardData (CardNumber, ExpDate, CVV) and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Parameter completion: (RecurlyToken, Error)
+    public func getToken(completion: @escaping (RecurlyToken?, RecurlyBaseErrorResponse?) -> ()) {
         
         let tokenizationRequest = RecurlyTokenRequest(
             cardData: cardData,
@@ -123,27 +134,7 @@ public final class RecurlyTokenizationManager {
             return
         }
         
-        var cancellable: AnyCancellable?
-        cancellable = apiClient.getTokenID(with: tokenizationRequest, requestType: .getTokenID).sink(receiveCompletion: { [weak self] result in
-            switch result {
-            case .failure(let error as RecurlyBaseErrorResponse):
-                completion(nil, error)
-            case .failure(let error):
-                completion(nil, RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
-                                                                         message: error.localizedDescription,
-                                                                         details: [])))
-            case .finished:
-                break
-            }
-            if let cancellable = cancellable {
-                self?.remove(cancellable)
-            }
-        }, receiveValue: { token in
-            completion(token, nil)
-        })
-        if let cancellable = cancellable {
-            store(cancellable)
-        }
+        subscribe(apiClient.getToken(with: tokenizationRequest, requestType: .getTokenID), completion: completion)
     }
     
     /// Returns the tokenId as String from a BillingInfo or/with ApplePaymentData, ApplePaymentMethod tokenization request.
@@ -153,6 +144,18 @@ public final class RecurlyTokenizationManager {
     ///
     /// - Parameter completion: (TokenId, Error)
     public func getApplePayTokenId(completion: @escaping (String?, RecurlyBaseErrorResponse?) -> ()) {
+        getApplePayToken { token, error in
+            completion(token?.id, error)
+        }
+    }
+    
+    /// Returns the tokenized `RecurlyToken` (id, type, and card metadata when present) from a BillingInfo or/with ApplePaymentData, ApplePaymentMethod tokenization request.
+    ///
+    /// Sends the ApplePaymentData (version, data, signature, header), ApplePaymentMethod (displayName, network, type)
+    /// and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Parameter completion: (RecurlyToken, Error)
+    public func getApplePayToken(completion: @escaping (RecurlyToken?, RecurlyBaseErrorResponse?) -> ()) {
         
         let applePayTokenizationRequest = RecurlyApplePayTokenRequest(paymentData: applePaymentData,
                                                                  paymentMethod: applePaymentMethod,
@@ -162,8 +165,22 @@ public final class RecurlyTokenizationManager {
                                                                  deviceId: getDeviceID(),
                                                                  sessionId: getSessionID())
         
+        subscribe(apiClient.getToken(with: applePayTokenizationRequest, requestType: .getApplePayTokenID), completion: completion)
+    }
+    
+    // MARK: - Helpers
+    
+    /// Subscribes to a tokenization publisher, bridging its result to `completion` and
+    /// handling the error-wrap/store/remove plumbing shared by every tokenization call.
+    private func subscribe<T>(_ publisher: AnyPublisher<T, Error>, completion: @escaping (T?, RecurlyBaseErrorResponse?) -> ()) {
+        // `didComplete` guards against a synchronously-completing publisher (e.g. the `Fail`
+        // publisher returned when request-building fails): `receiveCompletion` can run
+        // *inside* `sink(...)` while `cancellable` is still nil, so `remove` below is a no-op.
+        // Without this guard, `store` would then insert an already-completed cancellable that
+        // never gets removed, leaking it in `_subscriptions` for the life of the manager.
+        var didComplete = false
         var cancellable: AnyCancellable?
-        cancellable = apiClient.getTokenID(with: applePayTokenizationRequest, requestType: .getApplePayTokenID).sink(receiveCompletion: { [weak self] result in
+        cancellable = publisher.sink(receiveCompletion: { [weak self] result in
             switch result {
             case .failure(let error as RecurlyBaseErrorResponse):
                 completion(nil, error)
@@ -174,19 +191,18 @@ public final class RecurlyTokenizationManager {
             case .finished:
                 break
             }
+            didComplete = true
             if let cancellable = cancellable {
                 self?.remove(cancellable)
             }
-        }, receiveValue: { token in
-            completion(token, nil)
+        }, receiveValue: { value in
+            completion(value, nil)
         })
-        if let cancellable = cancellable {
+        if !didComplete, let cancellable = cancellable {
             store(cancellable)
         }
     }
-    
-    // MARK: - Helpers
-    
+
     /// Inserts `cancellable` into the subscription set atomically (single locked operation).
     private func store(_ cancellable: AnyCancellable) {
         withLock { _subscriptions.insert(cancellable) }

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -391,6 +391,86 @@ class RecurlySDK_iOSTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testRecurlyAPIClient_getToken_success_returnsFullTokenWithCard() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let responseJSON = """
+        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
+        """.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        let apiClient = RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession()))
+        let request = RecurlyTokenRequest(
+            cardData: RecurlyCardData(),
+            billingInfo: RecurlyBillingInfo(),
+            version: "1.0",
+            key: "key",
+            deviceId: "device",
+            sessionId: "session"
+        )
+
+        var cancellables = Set<AnyCancellable>()
+        let expectation = expectation(description: "getTokenSuccess")
+
+        apiClient.getToken(with: request, requestType: .getTokenID)
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    XCTFail("expected success")
+                }
+            }, receiveValue: { token in
+                XCTAssertEqual(token.id, "tok-abc")
+                XCTAssertEqual(token.type, "credit_card")
+                XCTAssertEqual(token.card?.brand, "visa")
+                XCTAssertEqual(token.card?.firstSix, "411111")
+                XCTAssertEqual(token.card?.lastFour, "1111")
+                XCTAssertEqual(token.card?.expMonth, 12)
+                XCTAssertEqual(token.card?.expYear, 2030)
+                XCTAssertEqual(token.card?.issuingCountry, "US")
+                XCTAssertEqual(token.card?.fundingSource, "credit")
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testRecurlyAPIClient_getTokenID_success_stillReturnsBareId_whenCardPresent() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let responseJSON = """
+        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
+        """.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        let apiClient = RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession()))
+        let request = RecurlyTokenRequest(
+            cardData: RecurlyCardData(),
+            billingInfo: RecurlyBillingInfo(),
+            version: "1.0",
+            key: "key",
+            deviceId: "device",
+            sessionId: "session"
+        )
+
+        var cancellables = Set<AnyCancellable>()
+        let expectation = expectation(description: "getTokenIDRegression")
+
+        apiClient.getTokenID(with: request, requestType: .getTokenID)
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    XCTFail("expected success")
+                }
+            }, receiveValue: { id in
+                XCTAssertEqual(id, "tok-abc")
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: RecurlyTokenizationManager
 
     func testRETokenizationManager_emptyCVV_doesNotHitNetwork() {
@@ -489,9 +569,105 @@ class RecurlySDK_iOSTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testRecurlyTokenizationManager_getToken_success_surfacesCard() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let responseJSON = """
+        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
+        """.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let expectation = expectation(description: "getTokenSuccess")
+        manager.getToken { token, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(token?.id, "tok-abc")
+            XCTAssertEqual(token?.card?.brand, "visa")
+            XCTAssertEqual(token?.card?.lastFour, "1111")
+            XCTAssertEqual(token?.card?.expMonth, 12)
+            XCTAssertEqual(token?.card?.expYear, 2030)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testRecurlyTokenizationManager_getToken_success_cardAbsent() {
+        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
+        let responseJSON = "{\"id\":\"tok-x\",\"type\":\"credit_card\"}".data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let expectation = expectation(description: "getTokenSuccess_cardAbsent")
+        manager.getToken { token, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(token?.id, "tok-x")
+            XCTAssertNil(token?.card)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testRecurlyTokenizationManager_getApplePayToken_success_surfacesCard() {
+        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
+        let responseJSON = """
+        {"id":"tok-apple-abc","type":"credit_card","card":{"brand":"master","first_six":"555555","last_four":"4444","exp_month":6,"exp_year":2029,"issuing_country":"ZZ","funding_source":"debit"}}
+        """.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+
+        let expectation = expectation(description: "getApplePayTokenSuccess")
+        manager.getApplePayToken { token, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(token?.id, "tok-apple-abc")
+            XCTAssertEqual(token?.card?.brand, "master")
+            XCTAssertEqual(token?.card?.lastFour, "4444")
+            XCTAssertEqual(token?.card?.issuingCountry, "ZZ")
+            XCTAssertEqual(token?.card?.fundingSource, "debit")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testRecurlyTokenizationManager_getApplePayTokenId_stillReturnsBareId_whenCardPresent() {
+        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
+        let responseJSON = """
+        {"id":"tok-apple-abc","type":"credit_card","card":{"brand":"master","first_six":"555555","last_four":"4444","exp_month":6,"exp_year":2029,"issuing_country":"ZZ","funding_source":"debit"}}
+        """.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+        }
+
+        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+
+        let expectation = expectation(description: "getApplePayTokenIdRegression")
+        manager.getApplePayTokenId { tokenId, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(tokenId, "tok-apple-abc")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // Note: getApplePayTokenId's `case .failure(let error):` non-RecurlyBaseErrorResponse
     // fallback (mirrors getTokenId's) is unreachable through the public API —
-    // RecurlyAPIClient.getTokenID only ever fails its publisher with RecurlyBaseErrorResponse.
+    // RecurlyAPIClient.getToken (used by both, via the shared `subscribe` helper) only ever
+    // fails its publisher with RecurlyBaseErrorResponse.
 
     // MARK: Model coding
 
@@ -500,6 +676,23 @@ class RecurlySDK_iOSTests: XCTestCase {
         let response = try JSONDecoder().decode(RecurlyTokenResponse.self, from: json)
         XCTAssertEqual(response.id, "tok-1")
         XCTAssertEqual(response.type, "credit_card")
+    }
+
+    func testRecurlyTokenResponse_decoding_withCard() throws {
+        let json = """
+        {"id":"tok-1","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(RecurlyTokenResponse.self, from: json)
+        XCTAssertEqual(response.id, "tok-1")
+        XCTAssertEqual(response.type, "credit_card")
+        let card = try XCTUnwrap(response.card)
+        XCTAssertEqual(card.brand, "visa")
+        XCTAssertEqual(card.firstSix, "411111")
+        XCTAssertEqual(card.lastFour, "1111")
+        XCTAssertEqual(card.expMonth, 12)
+        XCTAssertEqual(card.expYear, 2030)
+        XCTAssertEqual(card.issuingCountry, "US")
+        XCTAssertEqual(card.fundingSource, "credit")
     }
 
     func testREBaseErrorResponse_decoding() throws {

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -355,131 +355,83 @@ class RecurlySDK_iOSTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testREAPIClient_getTokenID_missingId_returnsSdkInternal() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = "{\"type\":\"credit_card\"}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+    // The tests below exercise `RecurlyAPIClient.makeToken(from:)` directly — the pure,
+    // side-effect-free mapping seam extracted from `getToken`'s `sendRequest` completion.
+    // This verifies the id-guard/card-mapping logic deterministically, without a real
+    // `URLSession` round-trip (see CI flake history on the previous MockURLProtocol-driven
+    // versions of these tests).
+
+    func testRecurlyAPIClient_makeToken_missingId_returnsSdkInternal() {
+        let response = RecurlyTokenResponse(type: "credit_card", id: nil, card: nil)
+
+        let result = RecurlyAPIClient.makeToken(from: .success(response))
+
+        guard case .failure(let error as RecurlyBaseErrorResponse) = result else {
+            XCTFail("expected sdk-internal failure")
+            return
         }
-
-        let apiClient = RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession()))
-        let request = RecurlyTokenRequest(
-            cardData: RecurlyCardData(),
-            billingInfo: RecurlyBillingInfo(),
-            version: "1.0",
-            key: "key",
-            deviceId: "device",
-            sessionId: "session"
-        )
-
-        var cancellables = Set<AnyCancellable>()
-        let expectation = expectation(description: "missingId")
-
-        apiClient.getTokenID(with: request, requestType: .getTokenID)
-            .sink(receiveCompletion: { completion in
-                if case .failure(let error as RecurlyBaseErrorResponse) = completion {
-                    XCTAssertEqual(error.error.code, "sdk-internal")
-                    expectation.fulfill()
-                } else {
-                    XCTFail("expected sdk-internal failure")
-                }
-            }, receiveValue: { _ in
-                XCTFail("expected no value")
-            })
-            .store(in: &cancellables)
-
-        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(error.error.code, "sdk-internal")
     }
 
-    func testRecurlyAPIClient_getToken_success_returnsFullTokenWithCard() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = """
-        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
-        """.data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+    func testRecurlyAPIClient_makeToken_success_returnsFullTokenWithCard() {
+        let card = RecurlyTokenCard(brand: "visa", firstSix: "411111", lastFour: "1111", expMonth: 12, expYear: 2030, issuingCountry: "US", fundingSource: "credit")
+        let response = RecurlyTokenResponse(type: "credit_card", id: "tok-abc", card: card)
+
+        let result = RecurlyAPIClient.makeToken(from: .success(response))
+
+        guard case .success(let token) = result else {
+            XCTFail("expected success")
+            return
         }
-
-        let apiClient = RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession()))
-        let request = RecurlyTokenRequest(
-            cardData: RecurlyCardData(),
-            billingInfo: RecurlyBillingInfo(),
-            version: "1.0",
-            key: "key",
-            deviceId: "device",
-            sessionId: "session"
-        )
-
-        var cancellables = Set<AnyCancellable>()
-        let expectation = expectation(description: "getTokenSuccess")
-
-        apiClient.getToken(with: request, requestType: .getTokenID)
-            .sink(receiveCompletion: { completion in
-                if case .failure = completion {
-                    XCTFail("expected success")
-                }
-            }, receiveValue: { token in
-                XCTAssertEqual(token.id, "tok-abc")
-                XCTAssertEqual(token.type, "credit_card")
-                XCTAssertEqual(token.card?.brand, "visa")
-                XCTAssertEqual(token.card?.firstSix, "411111")
-                XCTAssertEqual(token.card?.lastFour, "1111")
-                XCTAssertEqual(token.card?.expMonth, 12)
-                XCTAssertEqual(token.card?.expYear, 2030)
-                XCTAssertEqual(token.card?.issuingCountry, "US")
-                XCTAssertEqual(token.card?.fundingSource, "credit")
-                expectation.fulfill()
-            })
-            .store(in: &cancellables)
-
-        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(token.id, "tok-abc")
+        XCTAssertEqual(token.type, "credit_card")
+        XCTAssertEqual(token.card?.brand, "visa")
+        XCTAssertEqual(token.card?.firstSix, "411111")
+        XCTAssertEqual(token.card?.lastFour, "1111")
+        XCTAssertEqual(token.card?.expMonth, 12)
+        XCTAssertEqual(token.card?.expYear, 2030)
+        XCTAssertEqual(token.card?.issuingCountry, "US")
+        XCTAssertEqual(token.card?.fundingSource, "credit")
     }
 
-    func testRecurlyAPIClient_getTokenID_success_stillReturnsBareId_whenCardPresent() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = """
-        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
-        """.data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
+    func testRecurlyAPIClient_makeToken_stillReturnsBareId_whenCardPresent() {
+        let card = RecurlyTokenCard(brand: "visa", firstSix: "411111", lastFour: "1111", expMonth: 12, expYear: 2030, issuingCountry: "US", fundingSource: "credit")
+        let response = RecurlyTokenResponse(type: "credit_card", id: "tok-abc", card: card)
+
+        let result = RecurlyAPIClient.makeToken(from: .success(response)).map(\.id)
+
+        guard case .success(let id) = result else {
+            XCTFail("expected success")
+            return
         }
-
-        let apiClient = RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession()))
-        let request = RecurlyTokenRequest(
-            cardData: RecurlyCardData(),
-            billingInfo: RecurlyBillingInfo(),
-            version: "1.0",
-            key: "key",
-            deviceId: "device",
-            sessionId: "session"
-        )
-
-        var cancellables = Set<AnyCancellable>()
-        let expectation = expectation(description: "getTokenIDRegression")
-
-        apiClient.getTokenID(with: request, requestType: .getTokenID)
-            .sink(receiveCompletion: { completion in
-                if case .failure = completion {
-                    XCTFail("expected success")
-                }
-            }, receiveValue: { id in
-                XCTAssertEqual(id, "tok-abc")
-                expectation.fulfill()
-            })
-            .store(in: &cancellables)
-
-        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(id, "tok-abc")
     }
 
     // MARK: RecurlyTokenizationManager
 
-    func testRETokenizationManager_emptyCVV_doesNotHitNetwork() {
-        MockURLProtocol.requestHandler = { _ in
-            XCTFail("network should not be called when cvv is empty")
-            return (nil, nil, nil)
+    /// Minimal `TokenAPIClient` fake letting `RecurlyTokenizationManager` tests assert
+    /// delegation/validation logic deterministically (`Result.publisher` delivers
+    /// synchronously), without driving a real `URLSession` round-trip.
+    private struct StubTokenAPIClient: TokenAPIClient {
+        var result: Result<RecurlyToken, Error> = .success(RecurlyToken(id: "stub-unused", type: nil, card: nil))
+        var onCall: (() -> Void)? = nil
+
+        func getToken<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<RecurlyToken, Error> {
+            onCall?()
+            return result.publisher.eraseToAnyPublisher()
         }
 
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        func getTokenID<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<String, Error> {
+            getToken(with: dataRequest, requestType: requestType)
+                .map(\.id)
+                .eraseToAnyPublisher()
+        }
+    }
+
+    func testRETokenizationManager_emptyCVV_doesNotHitNetwork() {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(onCall: {
+            XCTFail("network should not be called when cvv is empty")
+        }))
         manager.cardData.cvv = ""
 
         let expectation = expectation(description: "emptyCvv")
@@ -492,13 +444,9 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRETokenizationManager_getTokenId_success() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = "{\"id\":\"tok-abc\",\"type\":\"credit_card\"}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: nil))
+        ))
         manager.cardData.number = "4111111111111111"
         manager.cardData.month = "12"
         manager.cardData.year = "2030"
@@ -514,13 +462,9 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRETokenizationManager_getTokenId_failureMapped() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let errorJSON = "{\"error\":{\"code\":\"invalid-parameter\",\"message\":\"bad card\",\"details\":[]}}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), errorJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "invalid-parameter", message: "bad card", details: [])))
+        ))
         manager.cardData.cvv = "123"
 
         let expectation = expectation(description: "tokenFailure")
@@ -532,15 +476,10 @@ class RecurlySDK_iOSTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-
     func testRETokenizationManager_getApplePayTokenId_success() {
-        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
-        let responseJSON = "{\"id\":\"tok-apple-abc\",\"type\":\"credit_card\"}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: nil))
+        ))
 
         let expectation = expectation(description: "applePayTokenSuccess")
         manager.getApplePayTokenId { tokenId, error in
@@ -552,13 +491,9 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRETokenizationManager_getApplePayTokenId_failureMapped() {
-        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
-        let errorJSON = "{\"error\":{\"code\":\"invalid-parameter\",\"message\":\"bad apple pay token\",\"details\":[]}}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), errorJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "invalid-parameter", message: "bad apple pay token", details: [])))
+        ))
 
         let expectation = expectation(description: "applePayTokenFailure")
         manager.getApplePayTokenId { tokenId, error in
@@ -570,15 +505,10 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRecurlyTokenizationManager_getToken_success_surfacesCard() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = """
-        {"id":"tok-abc","type":"credit_card","card":{"brand":"visa","first_six":"411111","last_four":"1111","exp_month":12,"exp_year":2030,"issuing_country":"US","funding_source":"credit"}}
-        """.data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let card = RecurlyTokenCard(brand: "visa", firstSix: "411111", lastFour: "1111", expMonth: 12, expYear: 2030, issuingCountry: "US", fundingSource: "credit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: card))
+        ))
         manager.cardData.number = "4111111111111111"
         manager.cardData.month = "12"
         manager.cardData.year = "2030"
@@ -598,13 +528,9 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRecurlyTokenizationManager_getToken_success_cardAbsent() {
-        let url = URL(string: "https://api.recurly.com/js/v1/tokens")!
-        let responseJSON = "{\"id\":\"tok-x\",\"type\":\"credit_card\"}".data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-x", type: "credit_card", card: nil))
+        ))
         manager.cardData.number = "4111111111111111"
         manager.cardData.month = "12"
         manager.cardData.year = "2030"
@@ -621,15 +547,10 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRecurlyTokenizationManager_getApplePayToken_success_surfacesCard() {
-        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
-        let responseJSON = """
-        {"id":"tok-apple-abc","type":"credit_card","card":{"brand":"master","first_six":"555555","last_four":"4444","exp_month":6,"exp_year":2029,"issuing_country":"ZZ","funding_source":"debit"}}
-        """.data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
 
         let expectation = expectation(description: "getApplePayTokenSuccess")
         manager.getApplePayToken { token, error in
@@ -645,15 +566,10 @@ class RecurlySDK_iOSTests: XCTestCase {
     }
 
     func testRecurlyTokenizationManager_getApplePayTokenId_stillReturnsBareId_whenCardPresent() {
-        let url = URL(string: "https://api.recurly.com/js/v1/apple_pay/token")!
-        let responseJSON = """
-        {"id":"tok-apple-abc","type":"credit_card","card":{"brand":"master","first_six":"555555","last_four":"4444","exp_month":6,"exp_year":2029,"issuing_country":"ZZ","funding_source":"debit"}}
-        """.data(using: .utf8)!
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url ?? url, statusCode: 200, httpVersion: nil, headerFields: nil), responseJSON, nil)
-        }
-
-        var manager = RecurlyTokenizationManager(apiClient: RecurlyAPIClient(networkEngine: NetworkEngine(session: MockURLProtocol.makeSession())))
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
 
         let expectation = expectation(description: "getApplePayTokenIdRegression")
         manager.getApplePayTokenId { tokenId, error in
@@ -840,7 +756,9 @@ class RecurlySDK_iOSTests: XCTestCase {
         manager.getTokenId { _, _ in
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1.0)
+        // Generous timeout: exercises the real dataTask(...).resume() wiring end-to-end
+        // (asserts the actual serialized wire body).
+        wait(for: [expectation], timeout: 10.0)
 
         let body = try XCTUnwrap(capturedBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])


### PR DESCRIPTION
## Summary

Adds an additive, backward-compatible way to retrieve card metadata returned by
Recurly's tokenization endpoint. The SDK previously decoded only the token `id`
and `type`, discarding the card details (`brand`, `first_six`, `last_four`,
`exp_month`, `exp_year`, `issuing_country`, `funding_source`) that the API
already returns. Integrators can now surface a card-on-file summary without a
separate lookup.

Existing `getTokenId` / `getApplePayTokenId` methods are unchanged and keep
returning the bare token id.

## Changes

- Add public `RecurlyToken` (`id`, `type`, `card`) and `RecurlyTokenCard`
  (`brand`, `firstSix`, `lastFour`, `expMonth`, `expYear`, `issuingCountry`,
  `fundingSource`) models.
- Add a `card` field to the existing token-response model so the card metadata
  Recurly already returns.
- Add `RecurlyTokenizationManager.getToken` and `getApplePayToken` returning the
  full `RecurlyToken`; reimplement `getTokenId` / `getApplePayTokenId` as thin
  delegations over them.
- Add `RecurlyAPIClient.getToken` as the single source of truth; `getTokenID`
  now maps from it.
- Extract a shared `subscribe` helper for the tokenization publisher plumbing.
- Add unit tests covering card decoding, card-present/absent paths, and bare-id
  regression coverage.
- Document `getToken` usage in the README with a cardholder-data handling note.