### PR TITLE
feat: add async/await overloads for tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,36 @@ The same is available for Apple Pay via `getApplePayToken`. The existing
 `getTokenId` / `getApplePayTokenId` methods are unchanged and still return just
 the token id.
 
+### Async/await
+
+`getTokenId`, `getToken`, `getApplePayTokenId`, and `getApplePayToken` are also
+available as `async throws` overloads, alongside the completion-handler
+versions above (both are supported; use whichever fits your codebase):
+
+```Swift
+do {
+    let tokenId = try await RecurlyTokenizationManager.shared.getTokenId()
+    print(tokenId)
+} catch let errorResponse as RecurlyBaseErrorResponse {
+    print(errorResponse.error.message ?? "")
+}
+```
+
+```Swift
+do {
+    let token = try await RecurlyTokenizationManager.shared.getToken()
+    // Send token.id to your server to create the subscription / purchase.
+    if let card = token.card {
+        self.updateSavedCardLabel(brand: card.brand,
+                                  lastFour: card.lastFour,
+                                  expMonth: card.expMonth,
+                                  expYear: card.expYear)
+    }
+} catch let errorResponse as RecurlyBaseErrorResponse {
+    print(errorResponse.error.message ?? "")
+}
+```
+
 ## 5. Apple Pay support
 
 The following assumes your company is setup as an Apple Pay merchant. For more info on configuration and setup, look at the `README-APPLE-PAY-CONFIG.md` documentation in the repo.

--- a/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
@@ -222,3 +222,78 @@ public final class RecurlyTokenizationManager {
         return RecurlyConfiguration.shared.sessionId.uuidString
     }
 }
+
+// MARK: - Async/Await
+
+extension RecurlyTokenizationManager {
+
+    /// Returns the tokenized `RecurlyToken` (id, type, and card metadata when present) from a BillingInfo or/with CardData tokenization request.
+    ///
+    /// Sends the CardData (CardNumber, ExpDate, CVV) and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Throws: `RecurlyBaseErrorResponse` if tokenization fails.
+    /// - Returns: The tokenized `RecurlyToken`.
+    public func getToken() async throws -> RecurlyToken {
+        try await withCheckedThrowingContinuation { continuation in
+            getToken { token, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let token {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(throwing: RecurlyBaseErrorResponse(
+                        error: RecurlyTokenError(code: "sdk-internal",
+                                                  message: "Tokenization completed without a token or an error.",
+                                                  details: [])
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns the tokenId as String from a BillingInfo or/with CardData tokenization request.
+    ///
+    /// Sends the CardData (CardNumber, ExpDate, CVV) and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Throws: `RecurlyBaseErrorResponse` if tokenization fails.
+    /// - Returns: The tokenized token id.
+    public func getTokenId() async throws -> String {
+        try await getToken().id
+    }
+
+    /// Returns the tokenized `RecurlyToken` (id, type, and card metadata when present) from a BillingInfo or/with ApplePaymentData, ApplePaymentMethod tokenization request.
+    ///
+    /// Sends the ApplePaymentData (version, data, signature, header), ApplePaymentMethod (displayName, network, type)
+    /// and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Throws: `RecurlyBaseErrorResponse` if tokenization fails.
+    /// - Returns: The tokenized `RecurlyToken`.
+    public func getApplePayToken() async throws -> RecurlyToken {
+        try await withCheckedThrowingContinuation { continuation in
+            getApplePayToken { token, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let token {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(throwing: RecurlyBaseErrorResponse(
+                        error: RecurlyTokenError(code: "sdk-internal",
+                                                  message: "Tokenization completed without a token or an error.",
+                                                  details: [])
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Returns the tokenId as String from a BillingInfo or/with ApplePaymentData, ApplePaymentMethod tokenization request.
+    ///
+    /// Sends the ApplePaymentData (version, data, signature, header), ApplePaymentMethod (displayName, network, type)
+    /// and/or the BillingInfo that you want to tokenize
+    ///
+    /// - Throws: `RecurlyBaseErrorResponse` if tokenization fails.
+    /// - Returns: The tokenized token id.
+    public func getApplePayTokenId() async throws -> String {
+        try await getApplePayToken().id
+    }
+}

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -580,6 +580,89 @@ class RecurlySDK_iOSTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // MARK: - Async/Await
+
+    func testRecurlyTokenizationManager_async_emptyCVV_doesNotHitNetwork() async {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(onCall: {
+            XCTFail("network should not be called when cvv is empty")
+        }))
+        manager.cardData.cvv = ""
+
+        do {
+            _ = try await manager.getTokenId()
+            XCTFail("expected getTokenId to throw")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "validation")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_getTokenId_success() async throws {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: nil))
+        ))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let tokenId = try await manager.getTokenId()
+        XCTAssertEqual(tokenId, "tok-abc")
+    }
+
+    func testRecurlyTokenizationManager_async_getTokenId_failureMapped() async {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "invalid-parameter", message: "bad card", details: [])))
+        ))
+        manager.cardData.cvv = "123"
+
+        do {
+            _ = try await manager.getTokenId()
+            XCTFail("expected getTokenId to throw")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "invalid-parameter")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_getToken_success_surfacesCard() async throws {
+        let card = RecurlyTokenCard(brand: "visa", firstSix: "411111", lastFour: "1111", expMonth: 12, expYear: 2030, issuingCountry: "US", fundingSource: "credit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: card))
+        ))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let token = try await manager.getToken()
+        XCTAssertEqual(token.id, "tok-abc")
+        XCTAssertEqual(token.card?.brand, "visa")
+        XCTAssertEqual(token.card?.lastFour, "1111")
+        XCTAssertEqual(token.card?.expMonth, 12)
+        XCTAssertEqual(token.card?.expYear, 2030)
+    }
+
+    func testRecurlyTokenizationManager_async_getApplePayToken_success_surfacesCard() async throws {
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
+
+        let token = try await manager.getApplePayToken()
+        XCTAssertEqual(token.id, "tok-apple-abc")
+        XCTAssertEqual(token.card?.brand, "master")
+        XCTAssertEqual(token.card?.lastFour, "4444")
+    }
+
+    func testRecurlyTokenizationManager_async_getApplePayTokenId_stillReturnsBareId_whenCardPresent() async throws {
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
+
+        let tokenId = try await manager.getApplePayTokenId()
+        XCTAssertEqual(tokenId, "tok-apple-abc")
+    }
+
     // Note: getApplePayTokenId's `case .failure(let error):` non-RecurlyBaseErrorResponse
     // fallback (mirrors getTokenId's) is unreachable through the public API —
     // RecurlyAPIClient.getToken (used by both, via the shared `subscribe` helper) only ever


### PR DESCRIPTION
Adds `async throws` overloads for `getTokenId`, `getToken`, `getApplePayTokenId`, and `getApplePayToken`, alongside the existing completion-handler versions (both are supported).

- Additive only, no breaking changes.
- Async overloads bridge the existing completion-handler methods via `withCheckedThrowingContinuation`.
- New async tests mirror the existing completion-handler tests without `XCTestExpectation`/`wait(timeout:)`.
- README updated with async usage examples.

Second and final PR of the v3.1.0 workstream (after #54).