### PR TITLE
feat: add async/await overloads for tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,40 @@ The same is available for Apple Pay via `getApplePayToken`. The existing
 `getTokenId` / `getApplePayTokenId` methods are unchanged and still return just
 the token id.
 
+### Async/await
+
+`getTokenId`, `getToken`, `getApplePayTokenId`, and `getApplePayToken` are also
+available as `async throws` overloads, alongside the completion-handler
+versions above (both are supported; use whichever fits your codebase):
+
+```Swift
+do {
+    let tokenId = try await RecurlyTokenizationManager.shared.getTokenId()
+    print(tokenId)
+} catch let errorResponse as RecurlyBaseErrorResponse {
+    print(errorResponse.error.message ?? "")
+} catch {
+    print(error)
+}
+```
+
+```Swift
+do {
+    let token = try await RecurlyTokenizationManager.shared.getToken()
+    // Send token.id to your server to create the subscription / purchase.
+    if let card = token.card {
+        self.updateSavedCardLabel(brand: card.brand,
+                                  lastFour: card.lastFour,
+                                  expMonth: card.expMonth,
+                                  expYear: card.expYear)
+    }
+} catch let errorResponse as RecurlyBaseErrorResponse {
+    print(errorResponse.error.message ?? "")
+} catch {
+    print(error)
+}
+```
+
 ## 5. Apple Pay support
 
 The following assumes your company is setup as an Apple Pay merchant. For more info on configuration and setup, look at the `README-APPLE-PAY-CONFIG.md` documentation in the repo.

--- a/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
+++ b/RecurlySDK-iOS/Networking/RecurlyTokenizationManager.swift
@@ -179,6 +179,7 @@ public final class RecurlyTokenizationManager {
         // Without this guard, `store` would then insert an already-completed cancellable that
         // never gets removed, leaking it in `_subscriptions` for the life of the manager.
         var didComplete = false
+        var didEmitValue = false
         var cancellable: AnyCancellable?
         cancellable = publisher.sink(receiveCompletion: { [weak self] result in
             switch result {
@@ -189,13 +190,19 @@ public final class RecurlyTokenizationManager {
                                                                          message: error.localizedDescription,
                                                                          details: [])))
             case .finished:
-                break
+                if !didEmitValue {
+                    completion(nil, RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "sdk-internal",
+                                                                             message: "Tokenization finished without returning a token.",
+                                                                             details: [])))
+                }
             }
             didComplete = true
             if let cancellable = cancellable {
                 self?.remove(cancellable)
             }
         }, receiveValue: { value in
+            guard !didEmitValue else { return }
+            didEmitValue = true
             completion(value, nil)
         })
         if !didComplete, let cancellable = cancellable {
@@ -220,5 +227,53 @@ public final class RecurlyTokenizationManager {
     
     private func getSessionID() -> String {
         return RecurlyConfiguration.shared.sessionId.uuidString
+    }
+}
+
+// MARK: - Async/Await
+
+extension RecurlyTokenizationManager {
+
+    /// Async overload of `getToken(completion:)`. Returns the tokenized `RecurlyToken`; throws `RecurlyBaseErrorResponse` on failure.
+    public func getToken() async throws -> RecurlyToken {
+        try await bridgedToken(getToken)
+    }
+
+    /// Async overload of `getTokenId(completion:)`. Returns the token id; throws `RecurlyBaseErrorResponse` on failure.
+    public func getTokenId() async throws -> String {
+        try await getToken().id
+    }
+
+    /// Async overload of `getApplePayToken(completion:)`. Returns the tokenized `RecurlyToken`; throws `RecurlyBaseErrorResponse` on failure.
+    public func getApplePayToken() async throws -> RecurlyToken {
+        try await bridgedToken(getApplePayToken)
+    }
+
+    /// Async overload of `getApplePayTokenId(completion:)`. Returns the token id; throws `RecurlyBaseErrorResponse` on failure.
+    public func getApplePayTokenId() async throws -> String {
+        try await getApplePayToken().id
+    }
+
+    /// Bridges a completion-handler tokenization call to async. The single-`completion`-call
+    /// contract of `subscribe(_:completion:)` is load-bearing here: a checked continuation
+    /// crashes if resumed twice.
+    private func bridgedToken(
+        _ call: (@escaping (RecurlyToken?, RecurlyBaseErrorResponse?) -> ()) -> Void
+    ) async throws -> RecurlyToken {
+        try await withCheckedThrowingContinuation { continuation in
+            call { token, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let token {
+                    continuation.resume(returning: token)
+                } else {
+                    continuation.resume(throwing: RecurlyBaseErrorResponse(
+                        error: RecurlyTokenError(code: "sdk-internal",
+                                                  message: "Tokenization completed without a token or an error.",
+                                                  details: [])
+                    ))
+                }
+            }
+        }
     }
 }

--- a/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
+++ b/RecurlySDK-iOSTests/RecurlySDK-iOSTests.swift
@@ -415,9 +415,13 @@ class RecurlySDK_iOSTests: XCTestCase {
     private struct StubTokenAPIClient: TokenAPIClient {
         var result: Result<RecurlyToken, Error> = .success(RecurlyToken(id: "stub-unused", type: nil, card: nil))
         var onCall: (() -> Void)? = nil
+        var finishesWithoutValue = false
 
         func getToken<T: Codable>(with dataRequest: T, requestType: TokenizationAPI) -> AnyPublisher<RecurlyToken, Error> {
             onCall?()
+            if finishesWithoutValue {
+                return Empty(completeImmediately: true).eraseToAnyPublisher()
+            }
             return result.publisher.eraseToAnyPublisher()
         }
 
@@ -578,6 +582,116 @@ class RecurlySDK_iOSTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Async/Await
+
+    func testRecurlyTokenizationManager_async_emptyCVV_doesNotHitNetwork() async {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(onCall: {
+            XCTFail("network should not be called when cvv is empty")
+        }))
+        manager.cardData.cvv = ""
+
+        do {
+            _ = try await manager.getTokenId()
+            XCTFail("expected getTokenId to throw")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "validation")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_getTokenId_success() async throws {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: nil))
+        ))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let tokenId = try await manager.getTokenId()
+        XCTAssertEqual(tokenId, "tok-abc")
+    }
+
+    func testRecurlyTokenizationManager_async_getTokenId_failureMapped() async {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "invalid-parameter", message: "bad card", details: [])))
+        ))
+        manager.cardData.cvv = "123"
+
+        do {
+            _ = try await manager.getTokenId()
+            XCTFail("expected getTokenId to throw")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "invalid-parameter")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_getToken_success_surfacesCard() async throws {
+        let card = RecurlyTokenCard(brand: "visa", firstSix: "411111", lastFour: "1111", expMonth: 12, expYear: 2030, issuingCountry: "US", fundingSource: "credit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-abc", type: "credit_card", card: card))
+        ))
+        manager.cardData.number = "4111111111111111"
+        manager.cardData.month = "12"
+        manager.cardData.year = "2030"
+        manager.cardData.cvv = "123"
+
+        let token = try await manager.getToken()
+        XCTAssertEqual(token.id, "tok-abc")
+        XCTAssertEqual(token.card?.brand, "visa")
+        XCTAssertEqual(token.card?.lastFour, "1111")
+        XCTAssertEqual(token.card?.expMonth, 12)
+        XCTAssertEqual(token.card?.expYear, 2030)
+    }
+
+    func testRecurlyTokenizationManager_async_getApplePayToken_success_surfacesCard() async throws {
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
+
+        let token = try await manager.getApplePayToken()
+        XCTAssertEqual(token.id, "tok-apple-abc")
+        XCTAssertEqual(token.card?.brand, "master")
+        XCTAssertEqual(token.card?.lastFour, "4444")
+    }
+
+    func testRecurlyTokenizationManager_async_getApplePayToken_failureMapped() async {
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .failure(RecurlyBaseErrorResponse(error: RecurlyTokenError(code: "invalid-parameter", message: "bad apple pay token", details: [])))
+        ))
+
+        do {
+            _ = try await manager.getApplePayToken()
+            XCTFail("expected getApplePayToken to throw")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "invalid-parameter")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_finishesWithoutValue_throwsInternal() async {
+        var stub = StubTokenAPIClient()
+        stub.finishesWithoutValue = true
+        let manager = RecurlyTokenizationManager(apiClient: stub)
+        manager.cardData.cvv = "123"
+
+        do {
+            _ = try await manager.getToken()
+            XCTFail("expected getToken to throw when the publisher finishes without a value")
+        } catch {
+            XCTAssertEqual((error as? RecurlyBaseErrorResponse)?.error.code, "sdk-internal")
+        }
+    }
+
+    func testRecurlyTokenizationManager_async_getApplePayTokenId_stillReturnsBareId_whenCardPresent() async throws {
+        let card = RecurlyTokenCard(brand: "master", firstSix: "555555", lastFour: "4444", expMonth: 6, expYear: 2029, issuingCountry: "ZZ", fundingSource: "debit")
+        let manager = RecurlyTokenizationManager(apiClient: StubTokenAPIClient(
+            result: .success(RecurlyToken(id: "tok-apple-abc", type: "credit_card", card: card))
+        ))
+
+        let tokenId = try await manager.getApplePayTokenId()
+        XCTAssertEqual(tokenId, "tok-apple-abc")
     }
 
     // Note: getApplePayTokenId's `case .failure(let error):` non-RecurlyBaseErrorResponse


### PR DESCRIPTION
Adds `async throws` overloads for `getTokenId`, `getToken`, `getApplePayTokenId`,
and `getApplePayToken`, alongside the existing completion-handler versions (both
are supported).

- Async overloads bridge the existing completion-handler methods through a shared
  `bridgedToken(_:)` helper via `withCheckedThrowingContinuation`.
- Hardened `subscribe(_:completion:)` to guarantee the completion fires exactly
  once: a publisher that finishes without emitting now surfaces an `sdk-internal`
  error instead of silently dropping the callback (which would hang the async
  bridge), and a second emitted value is ignored.
- New async tests mirror the existing completion-handler tests without
  `XCTestExpectation`/`wait(timeout:)`.
- README updated with async usage examples.